### PR TITLE
Revert "allow make local to run without ECR permission"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ eb-create-staging:
 .PHONY: dockerrun-latest
 dockerrun-latest:
 	@sed -i -r 's/website:[^"]+/website:'"latest"'/g' Dockerrun.aws.json
-	@sed -i -r 's/website:[^"]+/website:'"latest"'/g' docker-compose.prod.yml
+	@sed -i -r 's/website:[^"]+/website:'"latest"'/g' docker-compose.yml
 
 
 .PHONY: staging-deploy

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,7 +3,6 @@ services:
   nginx-proxy:
     restart: always
   website:
-    image: 357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/website:WS275.2
     restart: always
   acedb:
     image: 357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/acedb:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,7 @@ services:
       - "./proxy/conf.d:/etc/nginx/conf.d"
       - "./logs/nginx:/var/log/nginx"
   website:
-    build:
-      context: .
-      dockerfile: ./docker/Dockerfile
+    image: 357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/website:WS275.2
     init: true
     expose:
       - "5000"

--- a/release.sh
+++ b/release.sh
@@ -23,12 +23,12 @@ set -x #echo on
 
 # update Version in Dockerrun.aws.json and docker-compose.yml
 sed -i -r 's/website:[^"]+/website:'"$VERSION"'/g' Dockerrun.aws.json
-sed -i -r 's/website:[^"]+/website:'"$VERSION"'/g' docker-compose.prod.yml
+sed -i -r 's/website:[^"]+/website:'"$VERSION"'/g' docker-compose.yml
 
 # release commit
 git diff
 git add Dockerrun.aws.json
-git add docker-compose.prod.yml
+git add docker-compose.yml
 git commit -m "release $VERSION"
 git tag "$VERSION"
 git push origin "$VERSION"


### PR DESCRIPTION
This reverts commit 45d3d78a6e98ca375cd77fd28646cf1f97a6714f.

No longer needed, because `make local` no longer relies on docker-compose.yml. docker-compose.local.yml is self-contained. Due to 36dc92942c0752c7cc054b50e7e30fa8fb8ceda7 and other changes.