### PR TITLE
upgraded Mui typography to new version

### DIFF
--- a/client/src/components/ThemeProvider.js
+++ b/client/src/components/ThemeProvider.js
@@ -16,6 +16,9 @@ const wormbaseTheme = createMuiTheme({
     },
     error: errorColor,
   },
+  typography: {
+    useNextVariants: true,
+  },
 });
 
 const ThemeProvider = ({ children, ...props }) => (


### PR DESCRIPTION
Error:

![Screenshot 2020-03-15 at 12 01 46 AM](https://user-images.githubusercontent.com/43617894/76688139-3886da00-6650-11ea-9f40-85c9c55182d0.png)

Material-Ui notice:

```

The material design specification changed concerning variant names and styles. To allow a smooth 
transition we kept old variants and restyled variants for backwards compatibility but we log deprecation 
warnings. We will remove the old typography variants in the next major release v4.0.0 (Q1 2019)

```