### PR TITLE
solve DeprecationWarning

### DIFF
--- a/client/src/components/Sequence/StrandSelect.js
+++ b/client/src/components/Sequence/StrandSelect.js
@@ -11,6 +11,9 @@ import Tab from '../Tab';
 import Tabs from '../Tabs';
 
 const strandTheme = createMuiTheme({
+  typography: {
+    useNextVariants: true,
+  },
   palette: {
     primary: teal,
     secondary: pink,

--- a/client/src/components/ThemeProvider.js
+++ b/client/src/components/ThemeProvider.js
@@ -9,6 +9,9 @@ import primaryColor from '@material-ui/core/colors/blueGrey';
 import errorColor from '@material-ui/core/colors/red';
 
 const wormbaseTheme = createMuiTheme({
+  typography: {
+    useNextVariants: true,
+  },
   palette: {
     primary: primaryColor,
     secondary: {


### PR DESCRIPTION
I fixed the error in dev-tool console:
`Warning: Material-UI: you are using the deprecated typography variants that will be removed in the next major release. Please read the migration guide under https://v3.material-ui.com/style/typography/#migration-to-typography-v2`
