### PR TITLE
fix search functionality when no query is entered

### DIFF
--- a/root/js/wormbase.js
+++ b/root/js/wormbase.js
@@ -798,7 +798,7 @@ var name2widget = {
         f = f.replace('%26', '&');
         f = f.replace('%2F', '/');
 
-        location.href = '/search/' + cur_search_type + '/' + f + (cur_search_species_type ? '?species=' + cur_search_species_type : '');
+        location.href = '/search/' + cur_search_type + '/' + (f === '' ? '*' : f) + (cur_search_species_type ? '?species=' + cur_search_species_type : '');
     }
 
     function search_change(new_search) {


### PR DESCRIPTION
### Description
fixes #22 
<br>
Url on searching result page should be formed like:
```
https://wormbase.org/search/<Class>/<query>?species=<Species>
```
(e.g. https://wormbase.org/search/gene/foo?species=b_malayi)

But if query isn't  entered, malformed url will be created like:
```
https://wormbase.org/search/<Class>/?species=<Species>
```
(e.g. https://wormbase.org/search/gene/?species=b_malayi)

This behavior causes incorrect search results.
So fixed to insert wild-card to \<query\> block when query isn't entered, like below:

https://wormbase.org/search/gene/*?species=b_malayi

