### PR TITLE
extract hook scripts as rc file

### DIFF
--- a/client/.huskyrc
+++ b/client/.huskyrc
@@ -1,0 +1,5 @@
+{
+  "hooks": {
+    "pre-commit": "lint-staged"
+  }
+}

--- a/client/.lintstagedrc
+++ b/client/.lintstagedrc
@@ -1,0 +1,7 @@
+{
+  "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}": [
+    "prettier --config ./.prettierrc",
+    "prettier --write",
+    "git add"
+  ]
+}

--- a/client/package.json
+++ b/client/package.json
@@ -31,18 +31,6 @@
     "tippy.js": "^4.3.5",
     "venn.js": "^0.2.20"
   },
-  "lint-staged": {
-    "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}": [
-      "prettier --config ./.prettierrc",
-      "prettier --write",
-      "git add"
-    ]
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",


### PR DESCRIPTION
### description

[husky](https://github.com/typicode/husky) and [lint-staged](https://github.com/okonet/lint-staged) can be configured using rc file.

(ref: https://github.com/typicode/husky#upgrading-from-014)
(ref: https://github.com/okonet/lint-staged#configuration)

I think it is better to extract as rc file just like ```.prettierrc``` instead writing directly in ```package.json``` .