### PR TITLE
added pluralize as a dependency

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -22,6 +22,7 @@
     "json2csv": "^4.1.2",
     "jss": "^9.8.7",
     "lint-staged": "^8.1.7",
+    "pluralize": "^1.2.1",
     "popper.js": "^1.15.0",
     "prettier": "^1.17.1",
     "query-string": "5",

--- a/client/src/utils/index.js
+++ b/client/src/utils/index.js
@@ -1,6 +1,5 @@
-export function pluralize(word, count) {
-  return count > 1 ? `${word}s` : word;
-}
+import pluralize from 'pluralize';
+export { pluralize };
 
 export function capitalize(word) {
   if (word) {


### PR DESCRIPTION
https://github.com/WormBase/website-public/blob/be2d7ff0b74a10253a7f48ca4c84f20ff36ee6df/client/yarn.lock#L3353

shows that pluralize is a sub dependency of eslint and is installed locally , so I taught if replacing `pluralize` function in the `utils` file with a more reliable `pluralize` function from `pluralize ` library