### PR TITLE
Table filter options

### DIFF
--- a/packages/data-tables/src/components/TableFilterComboBox/TableFilterComboBox.js
+++ b/packages/data-tables/src/components/TableFilterComboBox/TableFilterComboBox.js
@@ -84,8 +84,9 @@ const TableFilterComboBox = ({ options, onChange }) => {
   } = useCombobox({
     inputValue,
     items: getFilteredItems(items),
-    onStateChange: ({ inputValue, type, selectedItem }) => {
-      console.log([inputValue, type, selectedItem]);
+    onStateChange: (change) => {
+      const { inputValue, type, selectedItem } = change;
+      console.log(JSON.stringify(change, null, 2));
       switch (type) {
         case useCombobox.stateChangeTypes.InputChange:
           setInputValue(inputValue);
@@ -99,7 +100,6 @@ const TableFilterComboBox = ({ options, onChange }) => {
             if (filterName && filterValue) {
               setInputValue('');
               addSelectedItem(selectedItem);
-              closeMenu();
               selectItem(null);
             } else {
               setInputValue(`${filterName} : `);
@@ -117,7 +117,6 @@ const TableFilterComboBox = ({ options, onChange }) => {
             } else {
               addSelectedItem(`search : ${selectedItem}`);
             }
-            closeMenu();
             selectItem(null);
           }
 
@@ -164,8 +163,11 @@ const TableFilterComboBox = ({ options, onChange }) => {
           <input
             {...getInputProps(
               getDropdownProps({
-                onFocus: openMenu,
-                onBlur: closeMenu,
+                onFocus: () => {
+                  if (!isOpen) {
+                    openMenu();
+                  }
+                },
                 onKeyDown: (event) => {
                   if (
                     event.key === 'Enter' &&

--- a/packages/data-tables/src/components/TableFilterComboBox/TableFilterComboBox.js
+++ b/packages/data-tables/src/components/TableFilterComboBox/TableFilterComboBox.js
@@ -210,17 +210,21 @@ const TableFilterComboBox = ({ options, onChange }) => {
       </div>
       <ul {...getMenuProps()} style={{ backgroundColor: '#eee' }}>
         {isOpen &&
-          getFilteredItems(items).map((item, index) => (
-            <li
-              style={
-                highlightedIndex === index ? { backgroundColor: '#bde4ff' } : {}
-              }
-              key={`${item}${index}`}
-              {...getItemProps({ item, index })}
-            >
-              {item}
-            </li>
-          ))}
+          getFilteredItems(items)
+            .slice(0, 100)
+            .map((item, index) => (
+              <li
+                style={
+                  highlightedIndex === index
+                    ? { backgroundColor: '#bde4ff' }
+                    : {}
+                }
+                key={`${item}${index}`}
+                {...getItemProps({ item, index })}
+              >
+                {item}
+              </li>
+            ))}
       </ul>
     </div>
   );

--- a/packages/data-tables/src/components/TableFilterComboBox/TableFilterComboBox.js
+++ b/packages/data-tables/src/components/TableFilterComboBox/TableFilterComboBox.js
@@ -133,14 +133,13 @@ const TableFilterComboBox = ({ options, onChange }) => {
 
   return (
     <div>
-      <label {...getLabelProps()}>
-        Search by keywords or filter by specific attributes:
-      </label>
       <div
         style={{
           display: 'flex',
           flexWrap: 'wrap',
+          alignItems: 'center',
           border: '1px solid #ccc',
+          padding: `0px ${2}px`,
         }}
       >
         {selectedItems.map((selectedItem, index) => (
@@ -148,8 +147,8 @@ const TableFilterComboBox = ({ options, onChange }) => {
             key={`selected-item-${index}`}
             {...getSelectedItemProps({ selectedItem, index })}
             style={{
-              padding: 5,
-              margin: 5,
+              padding: 4,
+              margin: `${4}px ${2}px`,
               backgroundColor: '#eee',
             }}
           >
@@ -164,6 +163,7 @@ const TableFilterComboBox = ({ options, onChange }) => {
           style={{
             flex: '1 0 500px',
             padding: 5,
+            boxSizing: 'border-box',
           }}
         >
           <input
@@ -193,6 +193,7 @@ const TableFilterComboBox = ({ options, onChange }) => {
                 },
               })
             )}
+            placeholder="Search by keywords or filter by specific criteria"
             style={{
               width: 'calc(100% - 60px)',
             }}
@@ -209,26 +210,42 @@ const TableFilterComboBox = ({ options, onChange }) => {
           <button {...getToggleButtonProps()} aria-label={'toggle menu'}>
             &#8595;
           </button>
+          <ul
+            {...getMenuProps()}
+            style={{
+              backgroundColor: '#eee',
+              position: 'absolute',
+              margin: 0,
+              padding: `0px ${4}px`,
+              width: '100%',
+              listStyleType: 'none',
+            }}
+          >
+            {isOpen && getFilteredItems(items).length
+              ? [
+                  <li style={{ padding: `${4}px 0` }}>
+                    <strong>Filter by:</strong>
+                  </li>,
+                  getFilteredItems(items)
+                    .slice(0, 100)
+                    .map((item, index) => (
+                      <li
+                        style={
+                          highlightedIndex === index
+                            ? { backgroundColor: '#bde4ff' }
+                            : {}
+                        }
+                        key={`${item}${index}`}
+                        {...getItemProps({ item, index })}
+                      >
+                        {item}
+                      </li>
+                    )),
+                ]
+              : null}
+          </ul>
         </div>
       </div>
-      <ul {...getMenuProps()} style={{ backgroundColor: '#eee' }}>
-        {isOpen &&
-          getFilteredItems(items)
-            .slice(0, 100)
-            .map((item, index) => (
-              <li
-                style={
-                  highlightedIndex === index
-                    ? { backgroundColor: '#bde4ff' }
-                    : {}
-                }
-                key={`${item}${index}`}
-                {...getItemProps({ item, index })}
-              >
-                {item}
-              </li>
-            ))}
-      </ul>
     </div>
   );
 };

--- a/packages/data-tables/src/components/TableFilterComboBox/TableFilterComboBox.js
+++ b/packages/data-tables/src/components/TableFilterComboBox/TableFilterComboBox.js
@@ -80,7 +80,6 @@ const TableFilterComboBox = ({ options, onChange }) => {
     reset: resetCombobox,
     selectItem,
     openMenu,
-    closeMenu,
     toggleMenu,
   } = useCombobox({
     inputValue,

--- a/packages/data-tables/src/components/TableFilterComboBox/TableFilterComboBox.js
+++ b/packages/data-tables/src/components/TableFilterComboBox/TableFilterComboBox.js
@@ -81,6 +81,7 @@ const TableFilterComboBox = ({ options, onChange }) => {
     selectItem,
     openMenu,
     closeMenu,
+    toggleMenu,
   } = useCombobox({
     inputValue,
     items: getFilteredItems(items),
@@ -127,6 +128,8 @@ const TableFilterComboBox = ({ options, onChange }) => {
     },
   });
 
+  const [isOpenByFocus, setIsOpenByFocus] = useState(false);
+
   return (
     <div>
       <label {...getLabelProps()}>Filering by:</label>
@@ -165,7 +168,15 @@ const TableFilterComboBox = ({ options, onChange }) => {
               getDropdownProps({
                 onFocus: () => {
                   if (!isOpen) {
+                    setIsOpenByFocus(true);
                     openMenu();
+                  }
+                },
+                onClick: () => {
+                  if (isOpenByFocus) {
+                    setIsOpenByFocus(false);
+                  } else {
+                    toggleMenu();
                   }
                 },
                 onKeyDown: (event) => {

--- a/packages/data-tables/src/components/TableFilterComboBox/TableFilterComboBox.js
+++ b/packages/data-tables/src/components/TableFilterComboBox/TableFilterComboBox.js
@@ -131,7 +131,9 @@ const TableFilterComboBox = ({ options, onChange }) => {
 
   return (
     <div>
-      <label {...getLabelProps()}>Filering by:</label>
+      <label {...getLabelProps()}>
+        Search by keywords or filter by specific attributes:
+      </label>
       <div
         style={{
           display: 'flex',

--- a/packages/data-tables/src/components/TableFilterComboBox/TableFilterComboBox.js
+++ b/packages/data-tables/src/components/TableFilterComboBox/TableFilterComboBox.js
@@ -21,7 +21,7 @@ const TableFilterComboBox = ({ options, onChange }) => {
         (item) => `${filterName} : ${item}`
       );
     } else {
-      return Object.keys(options);
+      return Object.keys(options).sort();
     }
   }, [options, inputValue]);
   const {

--- a/packages/data-tables/src/components/TableFilterComboBox/TableFilterComboBox.js
+++ b/packages/data-tables/src/components/TableFilterComboBox/TableFilterComboBox.js
@@ -80,6 +80,7 @@ const TableFilterComboBox = ({ options, onChange }) => {
     reset: resetCombobox,
     selectItem,
     openMenu,
+    closeMenu,
     toggleMenu,
   } = useCombobox({
     inputValue,
@@ -118,6 +119,7 @@ const TableFilterComboBox = ({ options, onChange }) => {
               addSelectedItem(`search : ${selectedItem}`);
             }
             selectItem(null);
+            closeMenu();
           }
 
           break;

--- a/packages/data-tables/src/components/TableFilterComboBox/TableFilterComboBox.js
+++ b/packages/data-tables/src/components/TableFilterComboBox/TableFilterComboBox.js
@@ -1,28 +1,29 @@
 import React, { useState, useMemo } from 'react';
 import { useCombobox, useMultipleSelection } from 'downshift';
-import matchSorter from 'match-sorter'
+import matchSorter from 'match-sorter';
 
 function parseSelectedItem(selectedItem) {
-  let [filterName, filterValue] = selectedItem.split(' : ', 2).map(value => value.trim())
+  let [filterName, ...filterValues] = selectedItem.split(' : ');
   return {
-    filterName,
-    filterValue,
-  }
+    filterName: filterName.trim(),
+    filterValue: filterValues.join(' : ').trim(),
+  };
 }
 
-const TableFilterComboBox = ({
-  options,
-  onChange,
-}) => {
-  const [inputValue, setInputValue] = useState('')
+const TableFilterComboBox = ({ options, onChange }) => {
+  const [inputValue, setInputValue] = useState('');
   const items = useMemo(() => {
-    const { filterName } = inputValue.match(/ : /) ? parseSelectedItem(inputValue) : {}
+    const { filterName } = inputValue.match(/ : /)
+      ? parseSelectedItem(inputValue)
+      : {};
     if (filterName) {
-      return (options[filterName] || []).map (item => `${filterName} : ${item}`)
+      return (options[filterName] || []).map(
+        (item) => `${filterName} : ${item}`
+      );
     } else {
-      return Object.keys(options)
+      return Object.keys(options);
     }
-  }, [options, inputValue])
+  }, [options, inputValue]);
   const {
     getSelectedItemProps,
     getDropdownProps,
@@ -31,30 +32,41 @@ const TableFilterComboBox = ({
     reset: resetMultiple,
     selectedItems,
   } = useMultipleSelection({
-    onSelectedItemsChange: ({selectedItems}) => {
-      onChange && onChange(selectedItems.map(item => {
-        const {filterName: key, filterValue: value} = parseSelectedItem(item);
-        return {
-          key,
-          value,
-        }
-      }))
+    onSelectedItemsChange: ({ selectedItems }) => {
+      onChange &&
+        onChange(
+          selectedItems.map((item) => {
+            const { filterName: key, filterValue: value } = parseSelectedItem(
+              item
+            );
+            return {
+              key,
+              value,
+            };
+          })
+        );
     },
-  })
-  const getFilteredItems = items => {
-    const {priorityItems, otherItems} = matchSorter(items, inputValue.trim()).reduce((result, item) => {
-      if (item.match(/\(.+\)$/)) {
-        result.priorityItems.push(item)
-      } else {
-        result.otherItems.push(item)
+  });
+  const getFilteredItems = (items) => {
+    const { priorityItems, otherItems } = matchSorter(
+      items,
+      inputValue.trim()
+    ).reduce(
+      (result, item) => {
+        if (item.match(/\(.+\)$/)) {
+          result.priorityItems.push(item);
+        } else {
+          result.otherItems.push(item);
+        }
+        return result;
+      },
+      {
+        priorityItems: [],
+        otherItems: [],
       }
-      return result
-    }, {
-      priorityItems: [],
-      otherItems: [],
-    })
-    return [...priorityItems, ...otherItems]
-  }
+    );
+    return [...priorityItems, ...otherItems];
+  };
 
   const {
     isOpen,
@@ -72,62 +84,64 @@ const TableFilterComboBox = ({
   } = useCombobox({
     inputValue,
     items: getFilteredItems(items),
-    onStateChange: ({inputValue, type, selectedItem}) => {
+    onStateChange: ({ inputValue, type, selectedItem }) => {
       console.log([inputValue, type, selectedItem]);
       switch (type) {
         case useCombobox.stateChangeTypes.InputChange:
-          setInputValue(inputValue)
+          setInputValue(inputValue);
 
-          break
+          break;
         case useCombobox.stateChangeTypes.InputKeyDownEnter:
         case useCombobox.stateChangeTypes.ItemClick:
         case useCombobox.stateChangeTypes.InputBlur:
           if (selectedItem) {
-            const { filterName, filterValue } =  parseSelectedItem(selectedItem)
+            const { filterName, filterValue } = parseSelectedItem(selectedItem);
             if (filterName && filterValue) {
-              setInputValue('')
-              addSelectedItem(selectedItem)
-              closeMenu()
-              selectItem(null)
+              setInputValue('');
+              addSelectedItem(selectedItem);
+              closeMenu();
+              selectItem(null);
             } else {
-              setInputValue(`${filterName} : `)
-              openMenu() // show suggestion on the values available for the key entered
+              setInputValue(`${filterName} : `);
+              openMenu(); // show suggestion on the values available for the key entered
             }
           }
 
-          break
+          break;
         case useCombobox.stateChangeTypes.FunctionSelectItem:
           if (selectedItem) {
-            setInputValue('')
-            const { filterName, filterValue } =  parseSelectedItem(selectedItem)
-            if (filterName && filterValue ) {
-              addSelectedItem(selectedItem)
+            setInputValue('');
+            const { filterName, filterValue } = parseSelectedItem(selectedItem);
+            if (filterName && filterValue) {
+              addSelectedItem(selectedItem);
             } else {
-              addSelectedItem(`search : ${selectedItem}`)
+              addSelectedItem(`search : ${selectedItem}`);
             }
-            closeMenu()
-            selectItem(null)
+            closeMenu();
+            selectItem(null);
           }
 
-          break
+          break;
         default:
-          break
+          break;
       }
     },
-  })
+  });
 
   return (
     <div>
       <label {...getLabelProps()}>Filering by:</label>
-      <div style={{
-        display: 'flex',
-        flexWrap: 'wrap',
-        border: '1px solid #ccc',
-      }}>
+      <div
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          border: '1px solid #ccc',
+        }}
+      >
         {selectedItems.map((selectedItem, index) => (
           <div
             key={`selected-item-${index}`}
-            {...getSelectedItemProps({selectedItem, index})}
+            {...getSelectedItemProps({ selectedItem, index })}
             style={{
               padding: 5,
               margin: 5,
@@ -135,38 +149,45 @@ const TableFilterComboBox = ({
             }}
           >
             {selectedItem}
-            <span
-              onClick={() => removeSelectedItem(selectedItem)}
-            >
+            <span onClick={() => removeSelectedItem(selectedItem)}>
               &#10005;
             </span>
           </div>
         ))}
-        <div {...getComboboxProps()}
+        <div
+          {...getComboboxProps()}
           style={{
             flex: '1 0 500px',
             padding: 5,
           }}
         >
           <input
-            {...getInputProps(getDropdownProps({
-              onFocus: openMenu,
-              onBlur: closeMenu,
-              onKeyDown: (event) => {
-                if (event.key === 'Enter' && highlightedIndex === -1 && inputValue) {
-                  selectItem(inputValue);
-                }
-              }
-            }))}
+            {...getInputProps(
+              getDropdownProps({
+                onFocus: openMenu,
+                onBlur: closeMenu,
+                onKeyDown: (event) => {
+                  if (
+                    event.key === 'Enter' &&
+                    highlightedIndex === -1 &&
+                    inputValue
+                  ) {
+                    selectItem(inputValue);
+                  }
+                },
+              })
+            )}
             style={{
               width: 'calc(100% - 60px)',
             }}
           />
-          <button onClick={() => {
-            setInputValue('')
-            resetCombobox()
-            resetMultiple()
-          }}>
+          <button
+            onClick={() => {
+              setInputValue('');
+              resetCombobox();
+              resetMultiple();
+            }}
+          >
             &#10005;
           </button>
           <button {...getToggleButtonProps()} aria-label={'toggle menu'}>
@@ -174,22 +195,22 @@ const TableFilterComboBox = ({
           </button>
         </div>
       </div>
-      <ul {...getMenuProps()} style={{backgroundColor: '#eee'}}>
+      <ul {...getMenuProps()} style={{ backgroundColor: '#eee' }}>
         {isOpen &&
           getFilteredItems(items).map((item, index) => (
             <li
               style={
-                highlightedIndex === index ? {backgroundColor: '#bde4ff'} : {}
+                highlightedIndex === index ? { backgroundColor: '#bde4ff' } : {}
               }
               key={`${item}${index}`}
-              {...getItemProps({item, index})}
+              {...getItemProps({ item, index })}
             >
               {item}
             </li>
           ))}
       </ul>
     </div>
-  )
-}
+  );
+};
 
 export default TableFilterComboBox;

--- a/packages/data-tables/src/components/TableFilterComboBox/index.stories.js
+++ b/packages/data-tables/src/components/TableFilterComboBox/index.stories.js
@@ -1,6 +1,6 @@
-import React, { useState, useEffect, useMemo } from 'react'
-import TableFilterComboBox, { useWormBaseTableFilter } from './index'
-import { useTable, useGlobalFilter } from 'react-table'
+import React, { useState, useEffect, useMemo } from 'react';
+import TableFilterComboBox, { useWormBaseTableFilter } from './index';
+import { useTable, useGlobalFilter } from 'react-table';
 import loadData from '../../services/loadData';
 
 export default {
@@ -8,33 +8,28 @@ export default {
 };
 
 export const mock = () => (
-  <TableFilterComboBox options={{
-    food: ['bread', 'egg', 'lettuce', 'tomato'],
-    drinks: ['water', 'soda', 'milk'],
-  }} />
+  <TableFilterComboBox
+    options={{
+      food: ['bread', 'egg', 'lettuce', 'tomato'],
+      drinks: ['water', 'soda', 'milk'],
+    }}
+  />
 );
 
-const CellDefault = ({value}) => <pre>{JSON.stringify(value, null, 2)}</pre>
+const CellDefault = ({ value }) => <pre>{JSON.stringify(value, null, 2)}</pre>;
 
-const GenericTestTable = ({
-  data = [],
-  columns: columnsRaw,
-}) => {
-
-  const {
-    filters,
-    setFilters,
-    options,
-    tableOptions,
-  } = useWormBaseTableFilter(data);
+const GenericTestTable = ({ data = [], columns: columnsRaw }) => {
+  const { filters, setFilters, options, tableOptions } = useWormBaseTableFilter(
+    data
+  );
 
   const columns = useMemo(() => {
-    return columnsRaw.map(columnRaw => ({
+    return columnsRaw.map((columnRaw) => ({
       Header: columnRaw.accessor,
       Cell: CellDefault,
       ...columnRaw,
-    }))
-  }, [columnsRaw])
+    }));
+  }, [columnsRaw]);
 
   const {
     getTableProps,
@@ -42,177 +37,196 @@ const GenericTestTable = ({
     headerGroups,
     rows,
     prepareRow,
-  } = useTable({
-    ...tableOptions,
-    columns,
-    data,
-  }, useGlobalFilter)
+  } = useTable(
+    {
+      ...tableOptions,
+      columns,
+      data,
+    },
+    useGlobalFilter
+  );
 
   return (
     <div>
       <TableFilterComboBox options={options} onChange={setFilters} />
       <pre>{JSON.stringify(filters, null, 2)}</pre>
       <table {...getTableProps()} style={{ border: 'solid 1px blue' }}>
-       <thead>
-         {headerGroups.map(headerGroup => (
-           <tr {...headerGroup.getHeaderGroupProps()}>
-             {headerGroup.headers.map(column => (
-               <th
-                 {...column.getHeaderProps()}
-                 style={{
-                   borderBottom: 'solid 3px red',
-                   background: 'aliceblue',
-                   color: 'black',
-                   fontWeight: 'bold',
-                 }}
-               >
-                 {column.render('Header')}
-               </th>
-             ))}
-           </tr>
-         ))}
-       </thead>
-       <tbody {...getTableBodyProps()}>
-         {rows.map(row => {
-           prepareRow(row)
-           return (
-             <tr {...row.getRowProps()}>
-               {row.cells.map(cell => {
-                 return (
-                   <td
-                     {...cell.getCellProps()}
-                     style={{
-                       padding: '10px',
-                       border: 'solid 1px gray',
-                       background: 'papayawhip',
-                     }}
-                   >
-                     {cell.render('Cell')}
-                   </td>
-                 )
-               })}
-             </tr>
-           )
-         })}
-       </tbody>
+        <thead>
+          {headerGroups.map((headerGroup) => (
+            <tr {...headerGroup.getHeaderGroupProps()}>
+              {headerGroup.headers.map((column) => (
+                <th
+                  {...column.getHeaderProps()}
+                  style={{
+                    borderBottom: 'solid 3px red',
+                    background: 'aliceblue',
+                    color: 'black',
+                    fontWeight: 'bold',
+                  }}
+                >
+                  {column.render('Header')}
+                </th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody {...getTableBodyProps()}>
+          {rows.slice(0, 100).map((row) => {
+            prepareRow(row);
+            return (
+              <tr {...row.getRowProps()}>
+                {row.cells.map((cell) => {
+                  return (
+                    <td
+                      {...cell.getCellProps()}
+                      style={{
+                        padding: '10px',
+                        border: 'solid 1px gray',
+                        background: 'papayawhip',
+                      }}
+                    >
+                      {cell.render('Cell')}
+                    </td>
+                  );
+                })}
+              </tr>
+            );
+          })}
+        </tbody>
       </table>
     </div>
-  )
-}
+  );
+};
 
-const useTableDataFetch = ({
-  wbId,
-  tableType,
-  defaultValue = [],
-}) => {
-  const [data, setData] = useState([])
-  const [error, setError] = useState(null)
-  const [loading, setLoading] = useState(true)
+const useTableDataFetch = ({ wbId, tableType, defaultValue = [] }) => {
+  const [data, setData] = useState([]);
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    loadData(wbId, tableType).then((json) => {
-      setData(json.data)
-      setLoading(false)
-    }).catch((error) => {
-      setError(error)
-      setLoading(false)
-    })
-  }, [wbId, tableType])
+    loadData(wbId, tableType)
+      .then((json) => {
+        setData(json.data);
+        setLoading(false);
+      })
+      .catch((error) => {
+        setError(error);
+        setLoading(false);
+      });
+  }, [wbId, tableType]);
 
   return {
     data,
     error,
     loading,
-  }
-}
+  };
+};
 
-const LoadDataProgress = ({children, ...useTableDataFetchOptions}) => {
-  const state = useTableDataFetch(useTableDataFetchOptions)
-  const { loading, error } = state
-  return (
-    loading ? 'Loading data from the server...' :
-    error ? <span style={{color: 'tomato'}}> Error occured loading data</span> :
+const LoadDataProgress = ({ children, ...useTableDataFetchOptions }) => {
+  const state = useTableDataFetch(useTableDataFetchOptions);
+  const { loading, error } = state;
+  return loading ? (
+    'Loading data from the server...'
+  ) : error ? (
+    <span style={{ color: 'tomato' }}> Error occured loading data</span>
+  ) : (
     children(state)
-  )
-}
+  );
+};
 
 export const PhenotypeAbi1 = () => {
-  const columns = useMemo(() => ([
-    {accessor: 'phenotype'},
-    {accessor: 'entity'},
-    {accessor: 'evidence'},
-  ]), [])
+  const columns = useMemo(
+    () => [
+      { accessor: 'phenotype' },
+      { accessor: 'entity' },
+      { accessor: 'evidence' },
+    ],
+    []
+  );
 
   return (
     <LoadDataProgress wbId="WBGene00015146" tableType="phenotype_flat">
-      {({data}) => <GenericTestTable data={data} columns={columns} />}
+      {({ data }) => <GenericTestTable data={data} columns={columns} />}
     </LoadDataProgress>
-  )
-}
+  );
+};
 
 export const PhenotypeByInteractionAbi1 = () => {
-
-  const columns = useMemo(() => ([
-    {accessor: 'phenotype'},
-    {accessor: 'interactions'},
-    {accessor: 'interaction_type'},
-    {accessor: 'citations'},
-  ]), [])
+  const columns = useMemo(
+    () => [
+      { accessor: 'phenotype' },
+      { accessor: 'interactions' },
+      { accessor: 'interaction_type' },
+      { accessor: 'citations' },
+    ],
+    []
+  );
 
   return (
-    <LoadDataProgress wbId="WBGene00015146" tableType="phenotype_by_interaction">
-      {({data}) => <GenericTestTable data={data} columns={columns} />}
+    <LoadDataProgress
+      wbId="WBGene00015146"
+      tableType="phenotype_by_interaction"
+    >
+      {({ data }) => <GenericTestTable data={data} columns={columns} />}
     </LoadDataProgress>
-  )
-}
+  );
+};
 
 export const BestBlastpMatchesAbi1 = () => {
-
-  const columns = useMemo(() => ([
-    {accessor: 'evalue'},
-    {accessor: 'taxonomy'},
-    {accessor: 'hit'},
-    {accessor: 'description'},
-    {accessor: 'percent'},
-  ]), [])
+  const columns = useMemo(
+    () => [
+      { accessor: 'evalue' },
+      { accessor: 'taxonomy' },
+      { accessor: 'hit' },
+      { accessor: 'description' },
+      { accessor: 'percent' },
+    ],
+    []
+  );
 
   return (
     <LoadDataProgress wbId="WBGene00015146" tableType="best_blastp_matches">
-      {({data}) => <GenericTestTable data={data.hits} columns={columns} />}
+      {({ data }) => <GenericTestTable data={data.hits} columns={columns} />}
     </LoadDataProgress>
-  )
-}
+  );
+};
 
 export const InteractionsAbi1 = () => {
-  const columns = useMemo(() => ([
-    {accessor: 'interactions'},
-    {accessor: 'type'},
-    {accessor: 'effector'},
-    {accessor: 'affected'},
-    {accessor: 'direction'},
-    {accessor: 'citations'},
-  ]), [])
+  const columns = useMemo(
+    () => [
+      { accessor: 'interactions' },
+      { accessor: 'type' },
+      { accessor: 'effector' },
+      { accessor: 'affected' },
+      { accessor: 'direction' },
+      { accessor: 'citations' },
+    ],
+    []
+  );
 
   return (
     <LoadDataProgress wbId="WBGene00015146" tableType="interactions">
-      {({data}) => <GenericTestTable data={data.edges} columns={columns} />}
+      {({ data }) => <GenericTestTable data={data.edges} columns={columns} />}
     </LoadDataProgress>
-  )
-}
+  );
+};
 
 export const InteractionsDaf2 = () => {
-  const columns = useMemo(() => ([
-    {accessor: 'interactions'},
-    {accessor: 'type'},
-    {accessor: 'effector'},
-    {accessor: 'affected'},
-    {accessor: 'direction'},
-    {accessor: 'citations'},
-  ]), [])
+  const columns = useMemo(
+    () => [
+      { accessor: 'interactions' },
+      { accessor: 'type' },
+      { accessor: 'effector' },
+      { accessor: 'affected' },
+      { accessor: 'direction' },
+      { accessor: 'citations' },
+    ],
+    []
+  );
 
   return (
     <LoadDataProgress wbId="WBGene00000898" tableType="interactions">
-      {({data}) => <GenericTestTable data={data.edges} columns={columns} />}
+      {({ data }) => <GenericTestTable data={data.edges} columns={columns} />}
     </LoadDataProgress>
-  )
-}
+  );
+};

--- a/packages/data-tables/src/components/TableFilterComboBox/useWormBaseTableFilter.js
+++ b/packages/data-tables/src/components/TableFilterComboBox/useWormBaseTableFilter.js
@@ -18,14 +18,13 @@ function flattenLossyRecursive(data, prefix = [], result = {}) {
     result[key] = result[key] || [];
     result[key].push(`${data.label} [${data.id}]`);
     return result;
-  } else if (Array.isArray(data)) {
-    data.forEach((item, i) => {
-      flattenLossyRecursive(item, prefix, result); // same prefix
-    });
-    return result;
   } else {
     Object.keys(data).forEach((key) => {
-      flattenLossyRecursive(data[key], [...prefix, key], result);
+      if (key === 'text' || parseInt(key) >= 0) {
+        flattenLossyRecursive(data[key], prefix, result); // same prefix
+      } else {
+        flattenLossyRecursive(data[key], [...prefix, key], result);
+      }
     });
     return result;
   }

--- a/packages/data-tables/src/services/loadData.js
+++ b/packages/data-tables/src/services/loadData.js
@@ -1,13 +1,27 @@
-const loadData = async (WBid, tableType) => {
-  const proxyUrl = 'https://calm-reaches-60051.herokuapp.com/'
-  const targetUrl =
-    tableType === 'blastp_details'
-      ? `http://wormbase.org/rest/field/protein/CE06236/${tableType}`
-      : `http://wormbase.org/rest/field/gene/${WBid}/${tableType}`
-  const res = await fetch(proxyUrl + targetUrl)
-  const json = await res.json()
-  const jsonSpecific = await json[`${tableType}`]
-  return jsonSpecific
-}
+const loadData = async (WBid, tableType, entityType = 'gene') => {
+  const proxyUrl = 'https://calm-reaches-60051.herokuapp.com/';
 
-export default loadData
+  let targetUrl;
+
+  switch (tableType) {
+    case 'blastp_details':
+      targetUrl = `http://wormbase.org/rest/field/protein/CE06236/${tableType}`;
+      break;
+
+    case 'phenotype_flat':
+    case 'phenotype_not_observed_flat':
+    case 'drives_overexpression_flat':
+      targetUrl = `http://staging.wormbase.org/rest/field/${entityType}/${WBid}/${tableType}`;
+      break;
+
+    default:
+      targetUrl = `http://wormbase.org/rest/field/${entityType}/${WBid}/${tableType}`;
+  }
+
+  const res = await fetch(proxyUrl + targetUrl);
+  const json = await res.json();
+  const jsonSpecific = await json[`${tableType}`];
+  return jsonSpecific;
+};
+
+export default loadData;


### PR DESCRIPTION
Apologies for the formatting changes introduced by prettier, causing the diffs harder to read.

Changes in this PR:
- Fixed the glitch that caused the failure to select the item being clicked on
- Better handling of list and tags when converting table data to filter options
- Made changes to `loadData` service, to use the staging API for certain tables (such as phenotype_flat). On the staging API, I changed the key in the `entity` attribute. The change should not affect the tables though.
- Made stylistic changes to the combo box