### PR TITLE
Gsoc tables style related fixes

### DIFF
--- a/packages/data-tables/.storybook/preview-head.html
+++ b/packages/data-tables/.storybook/preview-head.html
@@ -1,0 +1,1 @@
+<link href="https://wormbase.org/static/css/main.min.css" rel="stylesheet">

--- a/packages/data-tables/src/components/EvidenceCell.js
+++ b/packages/data-tables/src/components/EvidenceCell.js
@@ -30,8 +30,13 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const EvidenceCell = ({ renderContent, renderEvidence, data }) => {
-  const [expanded, setExpanded] = useState(true);
+const EvidenceCell = ({
+  renderContent,
+  renderEvidence,
+  data,
+  defaultExpanded = false,
+}) => {
+  const [expanded, setExpanded] = useState(defaultExpanded);
   const classes = useStyles();
 
   return (

--- a/packages/data-tables/src/components/EvidenceCell.js
+++ b/packages/data-tables/src/components/EvidenceCell.js
@@ -4,13 +4,53 @@ import Accordion from '@material-ui/core/Accordion';
 import AccordionDetails from '@material-ui/core/AccordionDetails';
 import AccordionSummary from '@material-ui/core/AccordionSummary';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    backgroundColor: 'transparent',
+    boxShadow: 'none',
+  },
+  accordionSummaryRoot: {
+    minHeight: 0,
+
+    '&.Mui-expanded': {
+      minHeight: 0,
+    },
+  },
+  accordionSummaryContent: {
+    margin: 0,
+
+    '&.Mui-expanded': {
+      margin: 0,
+    },
+  },
+  accordionSummaryExpandIcon: {
+    padding: 0,
+  },
+}));
 
 const EvidenceCell = ({ renderContent, renderEvidence, data }) => {
   const [expanded, setExpanded] = useState(true);
+  const classes = useStyles();
 
   return (
-    <Accordion expanded={expanded} onChange={() => setExpanded(!expanded)}>
-      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+    <Accordion
+      classes={{
+        root: classes.root,
+      }}
+      expanded={expanded}
+      onChange={() => setExpanded(!expanded)}
+    >
+      <AccordionSummary
+        classes={{
+          root: classes.accordionSummaryRoot,
+          content: classes.accordionSummaryContent,
+          expanded: classes.accordionSummaryExpanded,
+          expandIcon: classes.accordionSummaryExpandIcon,
+        }}
+        expandIcon={<ExpandMoreIcon fontSize="small" />}
+      >
         <div>
           {renderContent({
             contentData: data.text,

--- a/packages/data-tables/src/components/EvidenceCell.js
+++ b/packages/data-tables/src/components/EvidenceCell.js
@@ -13,6 +13,7 @@ const useStyles = makeStyles((theme) => ({
   },
   accordionSummaryRoot: {
     minHeight: 0,
+    paddingLeft: 0,
 
     '&.Mui-expanded': {
       minHeight: 0,

--- a/packages/data-tables/src/components/Generic.js
+++ b/packages/data-tables/src/components/Generic.js
@@ -43,7 +43,7 @@ const Generic = ({
         accessor: idx === 0 && hasGroupedRow ? `${ord}.label` : ord,
         Cell: ({ cell: { value } }) => {
           if (hasGroupedRow && value === null) {
-            return <span>N/A</span>;
+            return <SmartCell data="N/A" />;
           }
           return <SmartCell data={value} />;
         },

--- a/packages/data-tables/src/components/Generic.js
+++ b/packages/data-tables/src/components/Generic.js
@@ -9,7 +9,6 @@ import ReactHtmlParser from 'react-html-parser';
 
 const useStyles = makeStyles({
   columnHeader: {
-    fontSize: '1.1rem',
     fontWeight: '600',
     color: '#666',
   },

--- a/packages/data-tables/src/components/HashCell.js
+++ b/packages/data-tables/src/components/HashCell.js
@@ -22,7 +22,9 @@ const HashCell = ({ data, render }) => {
         .filter((key) => hasContent(data[key]))
         .map((key) => (
           <>
-            <dt key={key}>{key.replace(/_+/g, ' ')}:</dt>
+            <dt key={key}>
+              <SimpleCell>{key.replace(/_+/g, ' ')}:</SimpleCell>
+            </dt>
             <dd>{render({ elementValue: data[key] })}</dd>
           </>
         ))}

--- a/packages/data-tables/src/components/HashCell.js
+++ b/packages/data-tables/src/components/HashCell.js
@@ -1,14 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { makeStyles } from '@material-ui/core/styles';
 import { hasContent } from '../util/hasContent';
 import SimpleCell from './SimpleCell';
 
+const useStyles = makeStyles(() => ({
+  root: {
+    margin: 0,
+  },
+}));
+
 const HashCell = ({ data, render }) => {
+  const classes = useStyles();
+
   if (data.species) {
     return <SimpleCell data={`${data.genus}. ${data.species}`} />;
   }
   return (
-    <dl>
+    <dl className={classes.root}>
       {Object.keys(data)
         .filter((key) => hasContent(data[key]))
         .map((key) => (

--- a/packages/data-tables/src/components/HashCell.js
+++ b/packages/data-tables/src/components/HashCell.js
@@ -8,17 +8,16 @@ const HashCell = ({ data, render }) => {
     return <SimpleCell data={`${data.genus}. ${data.species}`} />;
   }
   return (
-    <ul>
+    <dl>
       {Object.keys(data)
         .filter((key) => hasContent(data[key]))
         .map((key) => (
-          <li key={key}>
-            {key.replace(/_+/g, ' ')}:
-            <br />
-            {render({ elementValue: data[key] })}
-          </li>
+          <>
+            <dt key={key}>{key.replace(/_+/g, ' ')}:</dt>
+            <dd>{render({ elementValue: data[key] })}</dd>
+          </>
         ))}
-    </ul>
+    </dl>
   );
 };
 

--- a/packages/data-tables/src/components/HashCell.js
+++ b/packages/data-tables/src/components/HashCell.js
@@ -1,15 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { hasContent } from '../util/hasContent';
-//import SimpleCell from './SimpleCell';
+import SimpleCell from './SimpleCell';
 
 const HashCell = ({ data, render }) => {
   if (data.species) {
-    return (
-      <span>
-        {data.genus}. {data.species}
-      </span>
-    );
+    return <SimpleCell data={`${data.genus}. ${data.species}`} />;
   }
   return (
     <ul>

--- a/packages/data-tables/src/components/ListCell.js
+++ b/packages/data-tables/src/components/ListCell.js
@@ -1,14 +1,30 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { makeStyles } from '@material-ui/core/styles';
 import { hasContent } from '../util/hasContent';
 
+const useStyles = makeStyles((theme) => ({
+  list: {
+    margin: 0,
+    padding: 0,
+    listStyleType: 'none',
+  },
+  listItem: {
+    margin: 0,
+    padding: 0,
+  },
+}));
+
 const ListCell = ({ data, render }) => {
+  const classes = useStyles();
   return (
-    <ul>
+    <ul className={classes.list}>
       {data
         .filter((dat) => hasContent(dat))
         .map((dat, index) => (
-          <li key={index}>{render({ elementData: dat })}</li>
+          <li key={index} className={classes.listItem}>
+            {render({ elementData: dat })}
+          </li>
         ))}
     </ul>
   );

--- a/packages/data-tables/src/components/SimpleCell.js
+++ b/packages/data-tables/src/components/SimpleCell.js
@@ -1,21 +1,31 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Link from './Link';
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    margin: `${theme.spacing(0.5)}px 0`,
+  },
+}));
 
 const SimpleCell = ({ data }) => {
+  const classes = useStyles();
+  let content;
+
   if (data !== null && typeof data === 'object') {
     if (data.text && typeof data.text !== 'object') {
-      return <span>{data.text}</span>;
+      content = data.text;
     } else if (data.class) {
-      return <Link {...data} />;
+      content = <Link {...data} />;
     } else {
-      return (
-        <span style={{ wordBreak: 'break-all' }}>{JSON.stringify(data)}</span>
-      );
+      content = JSON.stringify(data);
     }
   } else {
-    return <span>{data}</span>;
+    content = data;
   }
+
+  return <div className={classes.root}>{content}</div>;
 };
 
 SimpleCell.propTypes = {

--- a/packages/data-tables/src/components/SimpleCell.js
+++ b/packages/data-tables/src/components/SimpleCell.js
@@ -6,6 +6,7 @@ import { makeStyles } from '@material-ui/core/styles';
 const useStyles = makeStyles((theme) => ({
   root: {
     margin: `${theme.spacing(0.75)}px 0`,
+    overflowWrap: 'anywhere',
   },
 }));
 

--- a/packages/data-tables/src/components/SimpleCell.js
+++ b/packages/data-tables/src/components/SimpleCell.js
@@ -5,7 +5,7 @@ import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles((theme) => ({
   root: {
-    margin: `${theme.spacing(0.5)}px 0`,
+    margin: `${theme.spacing(0.75)}px 0`,
   },
 }));
 

--- a/packages/data-tables/src/components/SimpleCell.js
+++ b/packages/data-tables/src/components/SimpleCell.js
@@ -10,11 +10,13 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const SimpleCell = ({ data }) => {
+const SimpleCell = ({ data, children }) => {
   const classes = useStyles();
   let content;
 
-  if (data !== null && typeof data === 'object') {
+  if (children) {
+    content = children;
+  } else if (data !== null && typeof data === 'object') {
     if (data.text && typeof data.text !== 'object') {
       content = data.text;
     } else if (data.class) {

--- a/packages/data-tables/src/components/Table.js
+++ b/packages/data-tables/src/components/Table.js
@@ -24,7 +24,7 @@ import FilterListIcon from '@material-ui/icons/FilterList';
 import SortIcon from '@material-ui/icons/Sort';
 import Tsv from './Tsv';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles((theme) => ({
   wrapper: {
     display: 'block',
     overflow: 'auto',
@@ -96,13 +96,12 @@ const useStyles = makeStyles({
   },
   globalFilter: {
     backgroundColor: '#e9eef2',
-    textAlign: 'center',
+    display: 'flex',
     '& input': {
       borderRadius: 5,
-      fontSize: '1.2rem',
       border: '1px solid #ddd',
-      margin: '0.8rem 0',
-      width: '95%',
+      flex: '1 0 auto',
+      margin: `${theme.spacing(1.5)}px ${theme.spacing(0.5)}px 0`,
     },
   },
   pagination: {
@@ -121,7 +120,7 @@ const useStyles = makeStyles({
     backgroundColor: 'white',
     padding: 5,
   },
-});
+}));
 
 const GlobalFilter = ({ globalFilter, setGlobalFilter }) => {
   const [value, setValue] = useState(globalFilter);

--- a/packages/data-tables/src/components/TableHasGroupedRow.js
+++ b/packages/data-tables/src/components/TableHasGroupedRow.js
@@ -441,7 +441,7 @@ const TableHasGroupedRow = ({ columns, data, id, dataForTsv, order }) => {
   };
 
   const displayHiddenRowsCount = (cell, row) => {
-    if (cell.column.id === 'evidence' && row.subRows.length >= 10) {
+    if (cell.column.id === 'evidence') {
       return (
         <SimpleCell>
           {cell.render('Aggregated')}

--- a/packages/data-tables/src/components/TableHasGroupedRow.js
+++ b/packages/data-tables/src/components/TableHasGroupedRow.js
@@ -29,7 +29,7 @@ import FilterListIcon from '@material-ui/icons/FilterList';
 import Tsv from './Tsv';
 import SimpleCell from './SimpleCell';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles((theme) => ({
   wrapper: {
     display: 'block',
     overflow: 'auto',
@@ -99,13 +99,12 @@ const useStyles = makeStyles({
   },
   globalFilter: {
     backgroundColor: '#e9eef2',
-    textAlign: 'center',
+    display: 'flex',
     '& input': {
       borderRadius: 5,
-      fontSize: '1.2rem',
       border: '1px solid #ddd',
-      margin: '0.8rem 0',
-      width: '95%',
+      flex: '1 0 auto',
+      margin: `${theme.spacing(1.5)}px ${theme.spacing(0.5)}px 0`,
     },
   },
   pagination: {
@@ -128,7 +127,7 @@ const useStyles = makeStyles({
     marginRight: 10,
     verticalAlign: 'bottom',
   },
-});
+}));
 
 const GlobalFilter = ({ globalFilter, setGlobalFilter }) => {
   const [value, setValue] = useState(globalFilter);

--- a/packages/data-tables/src/components/TableHasGroupedRow.js
+++ b/packages/data-tables/src/components/TableHasGroupedRow.js
@@ -20,11 +20,14 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormGroup from '@material-ui/core/FormGroup';
 import FormLabel from '@material-ui/core/FormLabel';
 import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward';
-import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
+// import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
 import ArrowUpwardIcon from '@material-ui/icons/ArrowUpward';
-import ArrowRightIcon from '@material-ui/icons/ArrowRight';
+// import ArrowRightIcon from '@material-ui/icons/ArrowRight';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import ExpandLessIcon from '@material-ui/icons/ExpandLess';
 import FilterListIcon from '@material-ui/icons/FilterList';
 import Tsv from './Tsv';
+import SimpleCell from './SimpleCell';
 
 const useStyles = makeStyles({
   wrapper: {
@@ -121,11 +124,9 @@ const useStyles = makeStyles({
     backgroundColor: 'white',
     padding: 5,
   },
-  rows_count: {
-    '& .row-arrow-icon': {
-      fontSize: '1.5rem',
-      marginRight: 10,
-    },
+  rowArrowIcon: {
+    marginRight: 10,
+    verticalAlign: 'bottom',
   },
 });
 
@@ -442,17 +443,15 @@ const TableHasGroupedRow = ({ columns, data, id, dataForTsv, order }) => {
   const displayHiddenRowsCount = (cell, row) => {
     if (cell.column.id === 'evidence' && row.subRows.length >= 10) {
       return (
-        <>
+        <SimpleCell>
           {cell.render('Aggregated')}
-          <span className={classes.rows_count}>
-            {row.isExpanded ? (
-              <ArrowDropDownIcon className="row-arrow-icon" />
-            ) : (
-              <ArrowRightIcon className="row-arrow-icon" />
-            )}
-          </span>
-          {row.subRows.length} Results
-        </>
+          {row.isExpanded ? (
+            <ExpandLessIcon fontSize="small" className={classes.rowArrowIcon} />
+          ) : (
+            <ExpandMoreIcon fontSize="small" className={classes.rowArrowIcon} />
+          )}
+          <span>{row.subRows.length} Results</span>
+        </SimpleCell>
       );
     }
     return cell.render('Aggregated');


### PR DESCRIPTION
- import WormBase css to storybook to better visualize the end result in the context of the WormBase css
- standardized the margin and padding for various cells
- collapse evidence by default
- fix header fontSize
- fix alignment of global filter / search box 
- fix alignment of aggregated cell
