### PR TITLE
Fix HTML strings in the cell to be interpreted as HTML

### DIFF
--- a/packages/data-tables/src/components/SimpleCell.js
+++ b/packages/data-tables/src/components/SimpleCell.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Link from './Link';
 import { makeStyles } from '@material-ui/core/styles';
+import ReactHtmlParser from 'react-html-parser';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -28,7 +29,22 @@ const SimpleCell = ({ data, children }) => {
     content = data;
   }
 
-  return <div className={classes.root}>{content}</div>;
+  return (
+    <div className={classes.root}>
+      {typeof content === 'string'
+        ? ReactHtmlParser(content, {
+            transform: (node) => {
+              if (node.attribs?.onclick) {
+                return (
+                  <div dangerouslySetInnerHTML={{ __html: content }}></div>
+                );
+              }
+              return undefined;
+            },
+          })
+        : content}
+    </div>
+  );
 };
 
 SimpleCell.propTypes = {


### PR DESCRIPTION
HTML tag containing `onclick` attribute can't be interpreted keeping that attribute by using react-html-parser.
Hence, in those cases, used `dangerouslySetInnerHTML`