### PR TITLE
CSV downloads related updates and fixes

### DIFF
--- a/packages/data-tables/src/components/Generic.js
+++ b/packages/data-tables/src/components/Generic.js
@@ -58,6 +58,9 @@ const Generic = ({
     });
   }, []);
 
+  if (data.length === 0) {
+    return null;
+  }
   return (
     <>
       {hasGroupedRow ? (

--- a/packages/data-tables/src/components/Tsv.js
+++ b/packages/data-tables/src/components/Tsv.js
@@ -102,8 +102,15 @@ const Tsv = ({ data, id, order, ...otherProps }) => {
   );
 
   const uniqueKeysSortedByColumnOrder = order.map((ord) => {
-    const regex = new RegExp(`^${ord}.*`);
-    return uniqueKeys.filter((u) => regex.test(u)).sort();
+    const filterFunc = (fi) => {
+      const regex = new RegExp(`^${ord}\\..+`);
+      if (fi === ord || regex.test(fi)) {
+        return true;
+      }
+      return false;
+    };
+
+    return uniqueKeys.filter((u) => filterFunc(u)).sort();
   });
 
   return (

--- a/packages/data-tables/src/components/Tsv.js
+++ b/packages/data-tables/src/components/Tsv.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { CSVLink } from 'react-csv';
+import get from 'lodash/get';
 
 const Tsv = ({ data, id, order, ...otherProps }) => {
   const flattenRecursiveForTsv = (data, prefix = [], result = {}) => {
@@ -119,9 +120,47 @@ const Tsv = ({ data, id, order, ...otherProps }) => {
     return uniqueKeys.filter((u) => filterFunc(u)).sort();
   });
 
+  const sortByKey = (array, key) => {
+    const checkAndModify = (data) => {
+      if (data === undefined) {
+        return null;
+      }
+      if (!isNaN(Number(data))) {
+        return Number(data);
+      }
+      return data.toLowerCase();
+    };
+
+    return array.sort((a, b) => {
+      const ax = checkAndModify(get(a, key));
+      const bx = checkAndModify(get(b, key));
+      return ax === bx ? 0 : ax > bx ? 1 : -1;
+    });
+  };
+
+  const getKeyUsedByDefaultColumnSort = (keys) => {
+    if (keys[0].length === 1) {
+      return keys[0];
+    }
+
+    const regex = new RegExp(`.+\\.text$`);
+    const found = keys[0].find((k) => regex.test(k));
+    if (found) {
+      return found;
+    }
+
+    console.error(keys);
+    throw new Error(
+      'It is not possible to determine which key in the data is used for the default sorting'
+    );
+  };
+
   return (
     <CSVLink
-      data={flattenedData}
+      data={sortByKey(
+        flattenedData,
+        getKeyUsedByDefaultColumnSort(uniqueKeysSortedByColumnOrder)
+      )}
       headers={uniqueKeysSortedByColumnOrder.flat()}
       separator={','}
       filename={`${id}.csv`}

--- a/packages/data-tables/src/components/Tsv.js
+++ b/packages/data-tables/src/components/Tsv.js
@@ -87,6 +87,12 @@ const Tsv = ({ data, id, order, ...otherProps }) => {
       return result;
     }
 
+    // data: {Species}
+    if (data.species !== undefined && data.genus !== undefined) {
+      result['species'] = `${data.genus}. ${data.species}`;
+      return result;
+    }
+
     Object.keys(data).forEach((key) => {
       flattenRecursiveForTsv(data[key], [...prefix, key], result);
     });


### PR DESCRIPTION
- Rendering a table component before the data is passed would cause an error in the CSV downloads related component, so fixed that.
- CSV downloads for some tables would contain the same column multiple times.
Solved that problem by fixing the process of generating the column headers.
- In CSV downloads, Species data is now the same as it appears in the table, like `"C. remanei"` instead of `"C","remanei".`
- The default ascending sort of tables applied to first column is now applied to CSV downloads as well.