### PR TITLE
Make column sortable only containing no list type data

### DIFF
--- a/packages/data-tables/src/components/Generic.js
+++ b/packages/data-tables/src/components/Generic.js
@@ -22,7 +22,10 @@ const getDataForTsv = (data, property) => {
 };
 
 const disableSort = (data, ord) => {
-  if (data.some((dat) => Array.isArray(dat[ord]))) {
+  const ArrayHasMoreThanOneElement = (dat) =>
+    Array.isArray(dat[ord]) && dat[ord].length > 1;
+
+  if (data.some(ArrayHasMoreThanOneElement)) {
     return true;
   }
   return false;

--- a/packages/data-tables/src/components/Generic.js
+++ b/packages/data-tables/src/components/Generic.js
@@ -21,6 +21,13 @@ const getDataForTsv = (data, property) => {
   return null;
 };
 
+const disableSort = (data, ord) => {
+  if (data.some((dat) => Array.isArray(dat[ord]))) {
+    return true;
+  }
+  return false;
+};
+
 const Generic = ({
   data,
   id,
@@ -54,6 +61,7 @@ const Generic = ({
           }
         },
         Aggregated: () => null,
+        disableSortBy: disableSort(data, ord),
       };
     });
   }, []);

--- a/packages/data-tables/src/components/Wrapper.js
+++ b/packages/data-tables/src/components/Wrapper.js
@@ -45,7 +45,7 @@ const Wrapper = ({
 
   console.log(data);
 
-  return (
+  return data.length === 0 ? null : (
     <Generic
       data={data}
       id={id}


### PR DESCRIPTION
As a general rule, columns containing list type data(array type data) are no longer sortable.
The only exception is list type data none of them containing more than one element in the list.

E.g.
columns containing only like the following:
`["Rnaseq"]` or `[{...}]`
can be sortable.

columns containing like the following:
`[{...},{...}]` or `["aa","bb",cc"]`
can not be sortable.

This change caused an error when empty `data` variable is passed to `Generic` component, so fix to prevent that from happening is also included.