### PR TITLE
Improve the process of deciding how to sort each column

### DIFF
--- a/packages/data-tables/src/components/Generic.js
+++ b/packages/data-tables/src/components/Generic.js
@@ -64,7 +64,8 @@ const Generic = ({
           }
         },
         Aggregated: () => null,
-        disableSortBy: disableSort(data, ord),
+        disableSortBy:
+          idx !== 0 && hasGroupedRow ? true : disableSort(data, ord),
       };
     });
   }, []);


### PR DESCRIPTION
- Make only first column sortable in the grouped-row table
- Simplify the process of deciding how to sort each column and fix bug happened repeatedly in some tables, for example trying to apply `toLowerCase` function to a nullish value.