### PR TITLE
Fix column that contains HTML string data can be sorted properly

### DIFF
--- a/packages/data-tables/src/util/sortTypeHelper.js
+++ b/packages/data-tables/src/util/sortTypeHelper.js
@@ -39,6 +39,11 @@ const decideSortType = (rowA, rowB, columnId) => {
       return Number(toBeSorted);
     }
     if (typeof toBeSorted === 'string') {
+      // check if it contains HTML elements
+      if (/<\/?[a-z][\s\S]*>/i.test(toBeSorted)) {
+        // extract content from HTML string, and make it lower case
+        return toBeSorted.replace(/<[^>]+>/g, '').toLowerCase();
+      }
       return toBeSorted.toLowerCase();
     }
 


### PR DESCRIPTION
Allow sort properly, for example:
- Genetics widget > Strains table: "Strain", "Available from CGC?" column
- External Links widget's table: "Name", "Entry" column