### PR TITLE
stylistic fixes for grouped tables

### DIFF
--- a/packages/data-tables/src/components/Table.js
+++ b/packages/data-tables/src/components/Table.js
@@ -93,7 +93,12 @@ const useStyles = makeStyles((theme) => ({
       marginLeft: 5,
     },
   },
-  rowGrouped: {},
+  rowGrouped: {
+    borderTop: `1px solid ${theme.palette.divider}`,
+    '&:first-of-type': {
+      borderTop: 0,
+    },
+  },
   rowArrowIcon: {
     marginRight: 10,
     verticalAlign: 'middle',

--- a/packages/data-tables/src/components/Table.js
+++ b/packages/data-tables/src/components/Table.js
@@ -115,6 +115,9 @@ const useStyles = makeStyles((theme) => ({
   toolbarWrapper: {
     overflow: 'hidden', // work around -4px margin in Grid
   },
+  expandToggleLabel: {
+    padding: 0,
+  },
   toolbar: {
     padding: `${theme.spacing(0.5)}px ${theme.spacing(0.5)}px 0`,
 
@@ -314,6 +317,7 @@ const Table = ({
                 label={
                   isCellExpanded ? 'Details expanded' : 'Details collapsed'
                 }
+                className={classes.expandToggleLabel}
               />
             ) : null}
           </Grid>

--- a/packages/data-tables/src/components/Table.js
+++ b/packages/data-tables/src/components/Table.js
@@ -61,6 +61,7 @@ const useStyles = makeStyles((theme) => ({
     },
     '& .td': {
       // padding: '0.1rem 0.3rem',
+      display: 'flex',
     },
     '& .th:last-child, .td:last-child': {
       borderRight: 0,
@@ -101,7 +102,10 @@ const useStyles = makeStyles((theme) => ({
   },
   rowArrowIcon: {
     marginRight: 10,
-    verticalAlign: 'middle',
+    alignSelf: 'center',
+  },
+  annotationCount: {
+    display: 'inline-block',
   },
   subElement: {
     fontSize: '0.8em',
@@ -243,8 +247,12 @@ const Table = ({
           ) : (
             <ArrowRightIcon className={classes.rowArrowIcon} />
           )}
-          <SmartCell data={row.subRows[0].values[groupByID]} />
-          <small>{` ${row.subRows.length} annotation(s)`}</small>
+          <div>
+            <SmartCell data={row.subRows[0].values[groupByID]} />{' '}
+            <small
+              className={classes.annotationCount}
+            >{`${row.subRows.length} annotation(s)`}</small>
+          </div>
         </>
       );
     } else if (cell.isAggregated) {
@@ -370,7 +378,7 @@ const Table = ({
                           {...cell.getCellProps()}
                           className={decideClassNameOfCell(cell, idx)}
                         >
-                          <div>{renderCell(cell, row)}</div>
+                          {renderCell(cell, row)}
                         </div>
                       );
                     })}


### PR DESCRIPTION
- center the expend icon in grouped row
- prevent grouped row cell from being placed below the icon
- fix toggle padding 