### PR TITLE
use table_v2_args to hold additional arguments passed to table

### DIFF
--- a/root/templates/classes/gene/mapping_data.tt2
+++ b/root/templates/classes/gene/mapping_data.tt2
@@ -14,7 +14,7 @@
             key='two_pt_data',
             separator=' ',
             #style = 'aaSorting : [[0, "desc"]]'  // uncomment this if you need to sort descending,
-            args='{
+            table_v2_args='{
               tableConfig: WB.mappingDataTableConfig,
             }'
     );
@@ -31,7 +31,7 @@
             },
             separator=' ',
             key='multi_pt_data',
-            args='{
+            table_v2_args='{
               tableConfig: WB.mappingDataTableConfig,
             }');
     END;
@@ -46,7 +46,7 @@
             },
             key='pos_neg_data',
             separator=' ',
-            args='{
+            table_v2_args='{
               tableConfig: WB.mappingDataTableConfig,
             }'
             );

--- a/root/templates/shared/page_elements.tt2
+++ b/root/templates/shared/page_elements.tt2
@@ -363,7 +363,7 @@ END;
         %]
         <div id=[% table_id %]></div>
         <script type="text/javascript">
-          WB.buildDataTable("[% table_id %]", [% json_encode(local_data) %], [% json_encode(columns) %], [% json_encode(order) %] [% args.defined ? ", $args" : '' %]);
+          WB.buildDataTable("[% table_id %]", [% json_encode(local_data) %], [% json_encode(columns) %], [% json_encode(order) %] [% table_v2_args.defined ? ", $table_v2_args" : '' %]);
         </script>
         [%
 #       jquery_data_table_html(headers, local_data, "table_${key}_by" _ colorbox, style, table_build, order, separator, listener, column_args);


### PR DESCRIPTION
renamed from args to avoid naming conflict.