### PR TITLE
Gsoc tables spacing

### DIFF
--- a/packages/data-tables/src/components/Generic.js
+++ b/packages/data-tables/src/components/Generic.js
@@ -77,7 +77,7 @@ const getCellWith = (value) => {
 const getColumnWidth = (rows, accessor, headerText) => {
   const maxWidth = 400;
   const minWidth = 120;
-  const magicSpacing = 10;
+  const magicSpacing = 8;
   const cellLength = Math.max(
     ...rows.map((row) => getCellWith(row[accessor]))
     //headerText.length + 2,

--- a/packages/data-tables/src/components/Table.js
+++ b/packages/data-tables/src/components/Table.js
@@ -52,15 +52,15 @@ const useStyles = makeStyles((theme) => ({
     '& .is_not_sorted_odd_cell': {
       backgroundColor: '#fff',
     },
-    '& .th, .td': {
+    '& .th': {
       margin: 0,
       padding: `${theme.spacing(1)}px ${theme.spacing(1)}px`,
-      // borderBottom: '1px solid #ededed',
-      // borderRight: '1px solid #fff',
       position: 'relative',
     },
     '& .td': {
       // padding: '0.1rem 0.3rem',
+      margin: 0,
+      padding: `${theme.spacing(0.25)}px ${theme.spacing(1)}px`,
       display: 'flex',
     },
     '& .th:last-child, .td:last-child': {

--- a/packages/data-tables/src/components/Wrapper.js
+++ b/packages/data-tables/src/components/Wrapper.js
@@ -39,12 +39,16 @@ const Wrapper = ({ WBid, tableType, additionalKey = '', ...tableProps }) => {
   console.log(data);
 
   return data.length === 0 ? null : (
-    <Generic
-      data={data}
-      hasGroupedRow={hasGroupedRow(tableType)}
-      propertyForUnwinding={getPropertyForUnwinding(tableType)}
-      {...tableProps}
-    />
+    <div className="content">
+      {' '}
+      {/* additioanl selector matched by in main.css */}
+      <Generic
+        data={data}
+        hasGroupedRow={hasGroupedRow(tableType)}
+        propertyForUnwinding={getPropertyForUnwinding(tableType)}
+        {...tableProps}
+      />
+    </div>
   );
 };
 


### PR DESCRIPTION
- In Wrapper, mimic the context of the table as they appear in catalyst app
- Reduce vertical and horizontal spacing of a cell